### PR TITLE
Upload to path without a `+`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,10 @@ vsphere-version-dist: nodeup-dist protokube-export
 
 .PHONY: upload
 upload: version-dist # Upload kops to S3
+	# S3 doesn't handle + very well so we create a symlink to make
+	# `aws s3 sync` upload a redundant copy to an alternate, safer name.
+	# See also: https://forums.aws.amazon.com/thread.jspa?threadID=55746
+	ln -sf ${UPLOAD}/kops/${VERSION} ${UPLOAD}/kops/$(subst +,-,${VERSION})
 	aws s3 sync --acl public-read ${UPLOAD}/ ${S3_BUCKET}
 
 # gcs-upload builds kops and uploads to GCS


### PR DESCRIPTION
Upload a duplicate copy of our assets to a path that doesn't include a
`+` sign.

Although the S3 issue can be worked around by referencing the path as
`%2B`, it seems `kops`, via the Go `url` package, will aggressively
convert it back into a `+` and not re-encode it.  The kops and Go
behaviors would be fine if S3 followed the spec, but it doesn't.  The
easiest and safest work-around to this whole mess is to just not have
any + signs in our path.