### PR TITLE
fix: include volume used in volumeMounts

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -791,6 +791,12 @@ spec:
               name: etc-hosts
               readOnly: true
       volumes:
+        # Mount in the directory for host-local IPAM allocations. This is
+        # used when upgrading from host-local to calico-ipam, and can be removed
+        # if not using the upgrade-ipam init container.
+        - name: host-local-net-dir
+          hostPath:
+            path: /var/lib/cni/networks
         # Used by calico/node.
         - name: lib-modules
           hostPath:


### PR DESCRIPTION
**What this PR does**: This PR fixes the calico addon to have all the used volumeMounts in the volumes list for the calico-node daemonset